### PR TITLE
Fix Windows node vm box typo

### DIFF
--- a/4. 리눅스와 윈도우를 앤서블을 통해서 관리하기/4.3.1. 베이그런트를 이용해서 윈도우 노드를 추가하기/Vagrantfile
+++ b/4. 리눅스와 윈도우를 앤서블을 통해서 관리하기/4.3.1. 베이그런트를 이용해서 윈도우 노드를 추가하기/Vagrantfile
@@ -92,7 +92,7 @@ Vagrant.configure("2") do |config|
   
   #Ansible-Node07
   config.vm.define "ansible-node07" do |cfg|
-     cfg.vm.box = "sysnet4admin/windows2016"
+     cfg.vm.box = "sysnet4admin/Windows2016"
 	 cfg.vm.provider "virtualbox" do |vb|
 	   vb.name = "Ansible-Node07(github_SysNet4Admin)"
 	   vb.customize ['modifyvm', :id, '--clipboard', 'bidirectional']


### PR DESCRIPTION
change windows2016 to Windows2016 (uppercase)
can't download vm box image from vagrant cloud